### PR TITLE
Fix askpass loop hang

### DIFF
--- a/.obsidian/plugins/obsidian-git/obsidian_askpass.sh
+++ b/.obsidian/plugins/obsidian-git/obsidian_askpass.sh
@@ -10,9 +10,15 @@ trap cleanup EXIT
 
 echo "$PROMPT" > "$TEMP_FILE"
 
+TIMEOUT=30
+START=$(date +%s)
 while [ ! -e "$TEMP_FILE.response" ]; do
     if [ ! -e "$TEMP_FILE" ]; then
         echo "Trigger file got removed: Abort" >&2
+        exit 1
+    fi
+    if [ $(($(date +%s) - START)) -ge $TIMEOUT ]; then
+        echo "Timeout waiting for response" >&2
         exit 1
     fi
     sleep 0.1


### PR DESCRIPTION
## Summary
- add a timeout to the askpass helper used by obsidian-git

## Testing
- `bash -n .obsidian/plugins/obsidian-git/obsidian_askpass.sh`


------
https://chatgpt.com/codex/tasks/task_e_6875924e48208323a80d607da0f1089e