### PR TITLE
Organize docs directory and expand vault guides

### DIFF
--- a/docs/codebase_overview.md
+++ b/docs/codebase_overview.md
@@ -1,0 +1,52 @@
+---
+uniqueID: CO01
+title: codebase_overview.md
+tags:
+- guide
+- overview
+- meta
+---
+
+# Codebase Overview for Newcomers
+
+## General Structure
+- The repository is an Obsidian vault named **4_S0VRC3**, serving as the root for creative systems.
+- Core directories such as `REGEOS/`, `PROJECTS/`, `TEMPLATES/`, and `THREAD_DIGESTS/` organize protocol logic, active work, templates, and chat thread archives.
+- Index files like `SYSTEM_ROOT_README.md`, `folder_map.md`, and `vault_state.md` track catalogs, directory trees, and configuration notes.
+
+## Directory Breakdown
+| Path | Description |
+| --- | --- |
+| `REGEOS/` | System architecture and protocol logic. |
+| `PROJECTS/` | Active project spaces organized by UID. |
+| `TEMPLATES/` | Starting templates and metadata scaffolds. |
+| `THREAD_DIGESTS/` | ChatGPT thread archives. |
+| `ARCHIVAL_STACK/` | Deprecated or historical materials. |
+
+## Key Catalog Files
+- `FOLDER_CATALOG_FINAL.csv` – canonical folder list with UIDs and roles.
+- `THREAD_PROJECT_CROSSWALK_TAGGED.md` – maps thread IDs to projects and linkage status.
+- `SYSTEM_ROOT_README.md` – central index linking catalogs and guiding navigation.
+
+## Getting Started
+- Install Obsidian and clone or sync this vault.
+- Read `__VAULT_GUIDE__.md` for initial setup and orientation.
+- Use `folder_map.md` to get a quick sense of the directory layout.
+- Reference CSV catalogs when searching for specific UIDs or project folders.
+
+## Important Things to Know
+- Unique symbolic naming conventions and UIDs keep the vault organized; see `NAME_STRUCTURE_OVERVIEW.md` for rules.
+- `ARCHIVAL_STACK` holds archived thread digests summarizing historical ChatGPT conversations.
+- CSV catalogs help track folders and map threads to projects.
+
+## Pointers for Further Exploration
+1. **Project Folders** – Review individual project directories and their README files for scope and status.
+2. **Thread Mapping** – Consult `THREAD_PROJECT_CROSSWALK_TAGGED.md` and `SYMBOLIC_TREE_MAP.md` to connect threads with projects and symbolic systems.
+3. **Naming Conventions** – Study `NAME_STRUCTURE_OVERVIEW.md` to maintain consistent naming and UID usage.
+4. **System Evolution** – Read `CHANGELOG.md` and `vault_state.md` to see how the vault evolves and what tasks are pending.
+5. **Workflow Integration** – Consider how Obsidian Sync and plugins fit your workflow when adding new content.
+
+## Tools & Workflow Tips
+- Obsidian Sync keeps changes consistent across devices.
+- Markdown files include YAML front matter for metadata and tagging.
+- Commit updates through Git to maintain version history and collaboration.

--- a/docs/documentation_roadmap.md
+++ b/docs/documentation_roadmap.md
@@ -1,0 +1,35 @@
+---
+uniqueID: DR01
+title: documentation_roadmap.md
+tags:
+- planning
+- documentation
+- meta
+---
+
+# Documentation Roadmap
+
+## Why Expand the Doc Set?
+- Comparable Obsidian vaults and open-source repositories typically include dedicated guides, architecture notes, and contribution instructions.
+- A richer doc set will make this vault easier to navigate, onboard to, and maintain.
+
+## Proposed Documents
+- **Architecture Reference** – deeper explanation of relationships among `REGEOS`, `PROJECTS`, `THREAD_DIGESTS`, and catalogs.
+- **Contribution Guide** – workflow for adding threads, projects, and using naming conventions.
+- **Style Guide** – formatting rules for markdown, tags, and YAML front matter.
+- **Setup & Sync Guide** – steps to install Obsidian, required plugins, and sync configuration.
+- **Glossary** – definitions of symbolic IDs, abbreviations, and common terms.
+
+## Next Steps
+1. Create a `docs/` folder to house the above guides.
+2. Draft the architecture reference and contribution guide first.
+3. Review documentation patterns from comparable projects to adopt best practices.
+
+## Milestones
+- **Phase 1** – Establish the `docs/` directory and draft the architecture and contribution guides.
+- **Phase 2** – Add the style guide and setup instructions with examples.
+- **Phase 3** – Compile the glossary and automate indexing or linking between documents.
+
+## Resources to Review
+- `docs/codebase_overview.md` – high-level orientation for newcomers.
+- External open-source documentation such as Git or Obsidian community guides for style inspiration.

--- a/docs/expansion_ideas.md
+++ b/docs/expansion_ideas.md
@@ -1,0 +1,44 @@
+---
+uniqueID: EI01
+title: expansion_ideas.md
+tags:
+- planning
+- system
+- meta
+---
+
+# Expansion Ideas
+
+- **Automated Indexing & Navigation**
+  - Auto-generate index pages from CSV catalogs to keep folders and projects linked.
+  - Provide a dashboard or dynamic view to visualize vault state and tasks.
+- **Enhanced Thread ↔ Project Linking**
+  - Script new thread digests to update `THREAD_PROJECT_CROSSWALK` automatically.
+  - Add unique identifiers to each thread digest for easier cross-referencing.
+- **Template & Naming Automation**
+  - Expand `templates/` with scripts that enforce naming conventions and metadata.
+  - Offer quick commands in Obsidian to apply templates and naming patterns.
+- **Knowledge Graph Integrations**
+  - Use graph visualizers to map relationships between REGEOS, projects, and digests.
+  - Add metadata fields for domains, timeframes, and collaborators to enrich search.
+- **Versioning & History Tracking**
+  - Generate changelogs for critical catalogs or project files automatically.
+  - Use commit hooks to update project README files with status and timestamps.
+- **Onboarding Enhancements**
+  - Expand `__VAULT_GUIDE__.md` with a quick-start checklist.
+  - Include tutorial screencasts or screenshots showing naming conventions and cross-references.
+- **Documentation Depth**
+  - Develop a dedicated doc set (architecture reference, contribution guide, style guide).
+  - Survey similar knowledge repositories to adopt best documentation practices.
+
+- **Analytics & Search Enhancements**
+  - Implement full-text search or ranking to surface relevant digests and project notes.
+  - Track usage metrics or create dashboards that highlight active areas of the vault.
+
+- **Community & Collaboration**
+  - Provide contribution templates and clear issue-tracking practices for collaborators.
+  - Explore shared workspaces or publishing mechanisms for select documents.
+
+- **Long-Term Possibilities**
+  - Experiment with machine-assisted summarization of thread digests.
+  - Investigate export pipelines to formats like HTML or PDF for broader sharing.


### PR DESCRIPTION
## Summary
- move overview, roadmap, and expansion guides into a dedicated `docs/` folder
- add newcomer getting-started tips, workflow notes, and documentation milestones
- extend expansion ideas with analytics, collaboration, and long-term possibilities

## Testing
- `python -m py_compile walk_compare.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6875924ea87883239db98545a1ea49db