### PR TITLE
Add vault organization overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,16 @@ It is both a symbolic node and a practical sandbox.
 ## 🔒 Status
 Naming logic frozen as of `2025-05-04`
 Vault version: `v1.0`
+## 📂 Organization
+- `root_overview.md` — quick index of organizational files
+- `folder_map.md` — canonical vault tree
+- `FOLDER_CATALOG_FINAL.md` — UID list of major folders
+- `NAME_STRUCTURE_OVERVIEW.md` — naming conventions
+- `THREAD_PROJECT_CROSSWALK.md` — GPT thread index
+- `PR_FOLDERS_MASTER_INDEX_FINAL.md` — master project folder index
+- `GPT_PROJECTS_ARCHIVE.md` — archive of GPT projects
+- `SYSTEM_ROOT_README.md` — master navigation hub
+- `vault_state.md` — vault status
+- `CHANGELOG.md` — structural history
+- `organization_suggestions.md` — deduplication and folder structure recommendations
+

--- a/organization_suggestions.md
+++ b/organization_suggestions.md
@@ -1,0 +1,27 @@
+# ORGANIZATION_SUGGESTIONS
+
+Recommendations for cleaning up duplicates and clarifying the vault layout.
+
+## Duplicate File Candidates
+- **THREAD_PROJECT_CROSSWALK files** (`THREAD_PROJECT_CROSSWALK.md`, `THREAD_PROJECT_CROSSWALK_TAGGED.md`, `THREAD_PROJECT_CROSSWALK_FINAL.csv`)
+  - Keep the `.csv` as canonical; derive human-readable views from it.
+- **FOLDER_CATALOG_FINAL files** (`FOLDER_CATALOG_FINAL.md`, `FOLDER_CATALOG_FINAL.csv`)
+  - Consolidate into one source and auto-generate the alternate format.
+- **FOLDER_COLLAPSE_PLANNER.csv** vs. **FINAL_FOLDER_COLLAPSE_SNAPSHOT.csv**
+  - Archive planner once snapshot is finalized or merge into a single timeline.
+- **Untitled canvas files** (`Untitled.canvas`, `Untitled 1.canvas`)
+  - Remove or move into a dedicated `drafts/` area.
+- **ChatGPT instruction notes** (`ChatGPT-Disable Canvas Tool.md`, `ChatGPT-Merge Project Folders.md`)
+  - Combine into a single reference or relocate to `notes/`.
+- **Zipped artifacts** (`; RE•GE•OS ; RG•01 ;.zip`, `README_NOTES.zip`)
+  - Extract and file under `archive/`; remove the zip once contents are placed.
+
+## Suggested Folder Structure
+- `docs/` – READMEs, guides, naming conventions, and root_overview.
+- `datasets/` – CSV tables like crosswalks and catalogs.
+- `projects/` – active project directories.
+- `templates/` – reusable starter files.
+- `archive/` – historical snapshots and zipped exports.
+- `tags/` – tag dictionaries or mappings.
+
+Adopting these steps will reduce clutter and make the vault easier to navigate.

--- a/root_overview.md
+++ b/root_overview.md
@@ -1,0 +1,25 @@
+# ROOT_OVERVIEW
+
+This document provides a quick index of the key files that organize the `4_S0VRC3` vault.
+
+## Index
+- [folder_map.md](folder_map.md) — canonical directory tree
+- [FOLDER_CATALOG_FINAL.md](FOLDER_CATALOG_FINAL.md) — UID list for all major folders
+- [NAME_STRUCTURE_OVERVIEW.md](NAME_STRUCTURE_OVERVIEW.md) — naming conventions and UID logic
+- [THREAD_PROJECT_CROSSWALK.md](THREAD_PROJECT_CROSSWALK.md) — reference for all GPT threads
+- [SYMBOLIC_TREE_MAP.md](SYMBOLIC_TREE_MAP.md) — high-level thread to project map
+- [SYSTEM_ROOT_README.md](SYSTEM_ROOT_README.md) — master navigation file
+- [vault_state.md](vault_state.md) — current vault status
+- [CHANGELOG.md](CHANGELOG.md) — structural history
+- [__VAULT_GUIDE__.md](__VAULT_GUIDE__.md) — primer on using this archive
+- [PR_FOLDERS_MASTER_INDEX_FINAL.md](PR_FOLDERS_MASTER_INDEX_FINAL.md) — master index of project folders
+- [GPT_PROJECTS_ARCHIVE.md](GPT_PROJECTS_ARCHIVE.md) — archive of GPT projects
+- [THREAD_PROJECT_CROSSWALK_TAGGED.md](THREAD_PROJECT_CROSSWALK_TAGGED.md) — tagged thread crosswalk
+- [THREAD_PROJECT_CROSSWALK_FINAL.csv](THREAD_PROJECT_CROSSWALK_FINAL.csv) — final thread/project mapping dataset
+- [FOLDER_CATALOG_FINAL.csv](FOLDER_CATALOG_FINAL.csv) — tabular folder list
+- [FINAL_FOLDER_COLLAPSE_SNAPSHOT.csv](FINAL_FOLDER_COLLAPSE_SNAPSHOT.csv) — folder collapse snapshot
+- [FOLDER_COLLAPSE_PLANNER.csv](FOLDER_COLLAPSE_PLANNER.csv) — folder collapse planning sheet
+- [organization_suggestions.md](organization_suggestions.md) — deduplication and folder structure recommendations
+
+Use this overview as a landing page when exploring the repository.
+


### PR DESCRIPTION
## Summary
- expand `root_overview.md` with links to all discovered organizational files
- link `root_overview.md`, `PR_FOLDERS_MASTER_INDEX_FINAL.md`, and `GPT_PROJECTS_ARCHIVE.md` from `README.md`
- add `organization_suggestions.md` outlining duplicate cleanup and folder layout recommendations

## Testing
- `rg 'organization_suggestions' -n`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68759ea1800083238a450258bc9be879