### PR TITLE
Fix askpass loop hang

### DIFF
--- a/.obsidian/plugins/obsidian-git/obsidian_askpass.sh
+++ b/.obsidian/plugins/obsidian-git/obsidian_askpass.sh
@@ -3,6 +3,11 @@
 PROMPT="$1"
 TEMP_FILE="$OBSIDIAN_GIT_CREDENTIALS_INPUT"
 
+if [ -z "$TEMP_FILE" ]; then
+    echo "OBSIDIAN_GIT_CREDENTIALS_INPUT not set" >&2
+    exit 1
+fi
+
 cleanup() {
     rm -f "$TEMP_FILE" "$TEMP_FILE.response"
 }
@@ -10,12 +15,18 @@ trap cleanup EXIT
 
 echo "$PROMPT" > "$TEMP_FILE"
 
+TIMEOUT=30
+START=$(date +%s)
 while [ ! -e "$TEMP_FILE.response" ]; do
     if [ ! -e "$TEMP_FILE" ]; then
         echo "Trigger file got removed: Abort" >&2
         exit 1
     fi
-    sleep 0.1
+    if [ $(($(date +%s) - START)) -ge "$TIMEOUT" ]; then
+        echo "Timeout waiting for response" >&2
+        exit 1
+    fi
+    sleep 1
 done
 
 RESPONSE=$(cat "$TEMP_FILE.response")


### PR DESCRIPTION
## Summary
- add a timeout to the askpass helper used by obsidian-git
- bail out early when the credentials file isn't configured

## Testing
- `sh -n .obsidian/plugins/obsidian-git/obsidian_askpass.sh`
- `shellcheck .obsidian/plugins/obsidian-git/obsidian_askpass.sh`


------
https://chatgpt.com/codex/tasks/task_e_6875924e48208323a80d607da0f1089e