### PR TITLE
Enhance digest keyword scanner

### DIFF
--- a/keyword_matches.csv
+++ b/keyword_matches.csv
@@ -1,0 +1,12 @@
+thread_id,digest_path,title,keyword
+TH195,ARCHIVAL_STACK/PR02_THREAD_DIGEST.md,Universal Protocol Naming System,protocol
+TH282,ARCHIVAL_STACK/PR02_THREAD_DIGEST.md,Sharing System Protocols,protocol
+TH544,ARCHIVAL_STACK/PR02_THREAD_DIGEST.md,Naming System Optimization,naming
+TH140,ARCHIVAL_STACK/PR05_THREAD_DIGEST.md,Myth Drift Protocol,protocol
+TH259,ARCHIVAL_STACK/PR05_THREAD_DIGEST.md,Mythos Protocol Extraction,protocol
+TH347,ARCHIVAL_STACK/PR05_THREAD_DIGEST.md,Gabe Recursive Myth Protocol,protocol
+TH350,ARCHIVAL_STACK/PR05_THREAD_DIGEST.md,Mythic Yield Protocol Setup,protocol
+TH547,ARCHIVAL_STACK/PR08_THREAD_DIGEST.md,Technical Instructions Review Process,process
+TH204,ARCHIVAL_STACK/PR11_THREAD_DIGEST.md,ThreadHealth Check Protocol,protocol
+TH021,ARCHIVAL_STACK/PR12_THREAD_DIGEST.md,Symbolic Naming Evolution,naming
+TH261,ARCHIVAL_STACK/PR17_THREAD_DIGEST.md,Grant Protocols Iteration,protocol

--- a/walk_compare.py
+++ b/walk_compare.py
@@ -1,0 +1,121 @@
+"""Utility for scanning digest files for protocol-related keywords.
+
+The script walks ``ARCHIVAL_STACK`` for ``PR*_THREAD_DIGEST.md`` files, reads
+the thread table contained in each, and records rows whose titles mention one
+of the target keywords.  Results are appended to ``keyword_matches.csv`` with
+the thread ID, digest path, title, and the keyword that triggered the match.
+
+The behaviour can be customised via command-line arguments.  Run
+
+``python walk_compare.py --help``
+
+for details.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+from typing import Iterable, List, Tuple, Optional
+
+DEFAULT_KEYWORDS = ["protocol", "SOP", "process", "naming"]
+
+
+def _match_keyword(title: str, keywords: Iterable[str]) -> Optional[str]:
+    """Return the first keyword found in ``title`` or ``None``."""
+
+    lower_title = title.lower()
+    for kw in keywords:
+        kw_lower = kw.lower()
+        if kw_lower in lower_title:
+            return kw_lower
+    return None
+
+
+def _scan_file(path: Path, keywords: Iterable[str]) -> List[Tuple[str, str, str, str]]:
+    """Return matches from a single digest file.
+
+    Each match is a tuple of ``(thread_id, digest_path, title, keyword)``.
+    """
+
+    row_re = re.compile(r"^\|\s*(TH\d+)\s*\|\s*([^|]+?)\s*\|")
+    matches: List[Tuple[str, str, str, str]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            m = row_re.match(line)
+            if not m:
+                continue
+            thread_id, title = m.groups()
+            kw = _match_keyword(title, keywords)
+            if kw:
+                matches.append((thread_id, str(path), title.strip(), kw))
+    return matches
+
+
+def scan_digests(
+    digest_dir: Path = Path("ARCHIVAL_STACK"),
+    report_path: Path = Path("keyword_matches.csv"),
+    keywords: Iterable[str] = DEFAULT_KEYWORDS,
+) -> None:
+    """Scan ``digest_dir`` for keyword matches and append them to ``report_path``."""
+
+    digest_files = sorted(Path(digest_dir).glob("PR*_THREAD_DIGEST.md"))
+    matches: List[Tuple[str, str, str, str]] = []
+    for path in digest_files:
+        matches.extend(_scan_file(path, keywords))
+
+    # track existing entries to avoid duplicates
+    existing = set()
+    if report_path.exists():
+        with report_path.open(newline="", encoding="utf-8") as csvfile:
+            reader = csv.DictReader(csvfile)
+            for row in reader:
+                existing.add((row["thread_id"], row["digest_path"]))
+
+    write_header = not report_path.exists()
+    with report_path.open("a", newline="", encoding="utf-8") as csvfile:
+        fieldnames = ["thread_id", "digest_path", "title", "keyword"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        if write_header:
+            writer.writeheader()
+        for thread_id, dpath, title, keyword in matches:
+            key = (thread_id, dpath)
+            if key not in existing:
+                writer.writerow(
+                    {
+                        "thread_id": thread_id,
+                        "digest_path": dpath,
+                        "title": title,
+                        "keyword": keyword,
+                    }
+                )
+                existing.add(key)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scan digest files for protocol-related keywords."
+    )
+    parser.add_argument(
+        "--digest-dir", default="ARCHIVAL_STACK", help="Directory containing digest files"
+    )
+    parser.add_argument(
+        "--report",
+        default="keyword_matches.csv",
+        help="CSV file to append matches to",
+    )
+    parser.add_argument(
+        "--keywords",
+        default=",".join(DEFAULT_KEYWORDS),
+        help="Comma-separated list of keywords to search for",
+    )
+    args = parser.parse_args()
+
+    keywords = [k.strip() for k in args.keywords.split(",") if k.strip()]
+    scan_digests(Path(args.digest_dir), Path(args.report), keywords)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Extend `walk_compare.py` with CLI options, deduplication and explicit keyword capture when scanning digest files
- Expand `keyword_matches.csv` to include matched titles and keywords

## Testing
- `python walk_compare.py`
- `python -m py_compile walk_compare.py`


------
https://chatgpt.com/codex/tasks/task_e_689aa4f80b708323a029266a6fd3c7f3